### PR TITLE
fix(ui): Wizard-Tooltips nicht mehr abgeschnitten (Desktop + Mobile, beide Wizards)

### DIFF
--- a/static/shared.css
+++ b/static/shared.css
@@ -609,7 +609,7 @@
       letter-spacing: 0;
       text-transform: none;
       width: max-content;
-      max-width: 280px;
+      max-width: min(280px, calc(100vw - 2rem));
       white-space: normal;
       line-height: 1.5;
       box-shadow: 0 8px 24px rgba(0, 0, 0, .25);
@@ -630,6 +630,13 @@
       pointer-events: none;
       transition: opacity .18s;
     }
+    /* Kantenbewusst: JS setzt data-pos=left|right, wenn der ?-Button nahe am
+       Viewport-Rand sitzt — sonst würde die zentrierte Blase über den Rand
+       hinausragen und abgeschnitten (vorher zusätzlich von .step{overflow}).
+       Der Pfeil (.tip::before) bleibt mittig über dem ?, zeigt also korrekt. */
+    .tip[data-pos="left"]::after  { left: 0;    right: auto; transform: none; }
+    .tip[data-pos="right"]::after { left: auto; right: 0;    transform: none; }
+
     .tip:hover::after, .tip:focus::after, .tip.active::after,
     .tip:hover::before, .tip:focus::before, .tip.active::before {
       opacity: 1;

--- a/static/shared.css
+++ b/static/shared.css
@@ -156,17 +156,22 @@
       padding: 1.75rem 1.75rem 1.5rem;
       margin-bottom: 1.25rem;
       position: relative;
-      overflow: hidden;
       animation: fadeUp .4s ease both;
     }
     .step:nth-child(3) { animation-delay: .1s; }
     .step:nth-child(4) { animation-delay: .18s; }
 
+    /* Deko-Ziffer voll innerhalb der Card halten (kein overflow:hidden auf
+       .step nötig — das würde sonst die .tip-Tooltips abschneiden, die über
+       den Step-Rand hinausragen). Eigener overflow auf dem Pseudo behält den
+       angeschnittenen Riesenziffer-Look, ohne Kinder zu clippen. */
     .step::before {
       content: attr(data-step);
       position: absolute;
-      top: -.22em;
-      right: -.05em;
+      top: 0;
+      right: .4rem;
+      max-height: 6.4rem;
+      overflow: hidden;
       font-family: 'Fraunces', serif;
       font-size: 9rem;
       font-weight: 600;

--- a/templates/abrechnung.html
+++ b/templates/abrechnung.html
@@ -1711,6 +1711,21 @@
       });
     }
 
+    // Kantenbewusste Platzierung: data-pos verhindert (zusammen mit
+    // shared.css), dass die Tooltip-Blase über den Viewport-Rand ragt.
+    function placeTip(btn) {
+      const r = btn.getBoundingClientRect();
+      const vw = document.documentElement.clientWidth;
+      btn.dataset.pos = r.left < vw * 0.33 ? 'left'
+                      : r.left > vw * 0.67 ? 'right' : 'center';
+    }
+    document.addEventListener('mouseover', e => {
+      if (e.target.matches && e.target.matches('.tip')) placeTip(e.target);
+    });
+    document.addEventListener('focusin', e => {
+      if (e.target.matches && e.target.matches('.tip')) placeTip(e.target);
+    });
+
     // Tooltips per Klick toggeln (Mobile, ohne Hover)
     document.addEventListener('click', e => {
       const isTip = e.target.matches('.tip');
@@ -1718,6 +1733,7 @@
         if (t !== e.target) t.classList.remove('active');
       });
       if (isTip) {
+        placeTip(e.target);
         e.target.classList.toggle('active');
         e.preventDefault();
         e.stopPropagation();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1059,6 +1059,21 @@
         label.appendChild(btn);
       });
     }
+    // Kantenbewusste Platzierung: data-pos verhindert (zusammen mit
+    // shared.css), dass die Tooltip-Blase über den Viewport-Rand ragt.
+    function placeTip(btn) {
+      const r = btn.getBoundingClientRect();
+      const vw = document.documentElement.clientWidth;
+      btn.dataset.pos = r.left < vw * 0.33 ? 'left'
+                      : r.left > vw * 0.67 ? 'right' : 'center';
+    }
+    document.addEventListener('mouseover', e => {
+      if (e.target.matches && e.target.matches('.tip')) placeTip(e.target);
+    });
+    document.addEventListener('focusin', e => {
+      if (e.target.matches && e.target.matches('.tip')) placeTip(e.target);
+    });
+
     // Tooltips per Klick toggeln (Mobile, ohne Hover)
     document.addEventListener('click', e => {
       const isTip = e.target.matches('.tip');
@@ -1066,6 +1081,7 @@
         if (t !== e.target) t.classList.remove('active');
       });
       if (isTip) {
+        placeTip(e.target);
         e.target.classList.toggle('active');
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
## Kontext
QA-Pass über beide Wizards (Antrag `templates/index.html`, Abrechnung `templates/abrechnung.html`) nach PR #12 (Stepper-Wizard/Profil-Merge) + #13 (Tooltips). Playwright-verifiziert (Chromium, Desktop 1440×900 + Mobile 390×844), je 198 Before-/After-Screenshots.

## Defekt (1 Root-Cause, viele Ausprägungen): Tooltip-Blase abgeschnitten
Die `.tip`-Blase wurde geklippt — Desktop durch `.step{overflow:hidden}` (nur für die Deko-Riesenziffer da), Mobile zusätzlich durch den Viewport-Rand (zentrierte 280px-Blase). Betraf **beide** Wizards, Desktop **und** Mobile, linke **und** rechte Kante.

| Ausprägung | Before | After |
|---|---|---|
| Antrag, Desktop, `k_kosten_andere` (ursprünglich gemeldet, links abgeschnitten) | `screenshots/before-live__desktop__antrag-s4__tip-k_kosten_andere.png` | `screenshots/after-fixed__desktop__antrag-s4__tip-k_kosten_andere.png` |
| Antrag, Desktop, `r_zielort` (links abgeschnitten) | `screenshots/before-live__desktop__antrag-s4__tip-r_zielort.png` | `screenshots/after-fixed__desktop__antrag-s4__tip-r_zielort.png` |
| Abrechnung, Mobile, `f_verz_uebern` (rechts abgeschnitten) | `screenshots/before-live__mobile__abr-s8__tip-f_verz_uebern.png` | `screenshots/after-fixed__mobile__abr-s8__tip-f_verz_uebern.png` |
| Abrechnung, Mobile, `f_iban` (links abgeschnitten) | `screenshots/before-live__mobile__abr-s2__tip-f_iban.png` | `screenshots/after-fixed__mobile__abr-s2__tip-f_iban.png` |

Screenshot-Basis: `~/Developer/dr-automate-qa/screenshots/` (Schema `{before-live|after-fixed}__{desktop|mobile}__{wizard-step}__tip-{id}.png`).

## Fix
- `static/shared.css`: `.step{overflow:hidden}` entfernt; Deko-Ziffer `.step::before` voll in die Card geholt + per eigenem `overflow/max-height` angeschnitten (Look bleibt, clippt keine Kinder). Tooltip-`max-width` auf `min(280px, 100vw-2rem)` gedeckelt; `data-pos=left|right`-Varianten.
- `templates/index.html` + `templates/abrechnung.html`: `placeTip()` setzt `data-pos` kantenbewusst bei hover/focus/click (identischer Tooltip-Code in beiden).

## Geprüft (Playwright-Log im Transcript)
Beide Wizards komplett durchgesteppt, jeder `.tip` getriggert, jede Checkbox getoggelt, AI-Populate via `pasteJson` mit Sample „Schulungsgebühr 590 € netto inkl. Übernachtung und Verpflegung". Tooltip-Clipping (L/R/Top), Label-Wrapping, Layout-Overflow, Mobile-Breakpoint, Focus/Contrast, vorab-gecheckte Boxen — alle geprüft. **0 Console-Errors**. Deko-Ziffer-Rendering (Regression-Check) intakt.

## Bewusst NICHT geändert
`kosten_durch_andere_stelle` ist nach AI-Populate vorab gecheckt — das ist **spec-konform** (`system_prompt.md:36`: „Veranstalter trägt Reisekosten ganz/teilweise — typisch: Tagungsgebühr inkl. Übernachtung/Verpflegung"; Sample-Text triggert genau das). `system_prompt.md` unverändert (0-Zeilen-Diff). Kein Profil-Merge-Bug (`apply_profile_authoritative` rührt `konfiguration_checkboxen` nicht an).

## Offene Produktfragen (nicht Teil dieses PRs)
1. Soll die AI bei `kosten_durch_andere_stelle` konservativer sein (nur wenn explizit „Veranstalter übernimmt Reisekosten" statt schon bei „Gebühr inkl. Verpflegung")? = `system_prompt.md`-Änderung, bewusst ausgelassen.
2. „Profil einrichten"-Modal öffnet sich für Gäste ohne Profil automatisch (index.html `setTimeout(openWizard,400)`) — by design Onboarding; gewünscht so?
3. Globaler Header bricht auf Mobile auf zwei Zeilen („dr / automate") — kosmetisch, pre-existing, kein Wizard-Regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)