### PR TITLE
feat(profil): Amtsbezeichnung im Profil → Abrechnungs-Signaturzeile

### DIFF
--- a/alembic/versions/007_amtsbezeichnung.py
+++ b/alembic/versions/007_amtsbezeichnung.py
@@ -1,0 +1,29 @@
+"""amtsbezeichnung im profil
+
+Revision ID: 007_amtsbezeichnung
+Revises: 006_standard_verkehrsmittel
+Create Date: 2026-05-16
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "007_amtsbezeichnung"
+down_revision: str | None = "006_standard_verkehrsmittel"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("user_profiles") as batch:
+        batch.add_column(sa.Column("amtsbezeichnung", sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_profiles") as batch:
+        batch.drop_column("amtsbezeichnung")

--- a/app.py
+++ b/app.py
@@ -187,6 +187,7 @@ def _build_wizard_profile_seed(user) -> dict | None:
         return {
             "name": full_name,
             "abteilung": profile.abteilung or "",
+            "amtsbezeichnung": profile.amtsbezeichnung or "",
             "telefon": profile.telefon or "",
             "adresse": profile.adresse_privat or "",
             "mitreisender": profile.mitreisender_name_default or "",
@@ -272,6 +273,7 @@ def _profile_antrag_overrides(user) -> tuple[dict | None, dict | None]:
         antragsteller = {
             "name": name,
             "abteilung": p.abteilung or "",
+            "amtsbezeichnung": p.amtsbezeichnung or "",
             "telefon": p.telefon or "",
             "adresse_privat": p.adresse_privat or "",
             "mitreisender_name": p.mitreisender_name_default or "",
@@ -714,6 +716,7 @@ _PROFIL_FIELDS_TEXT = {
     "vorname",
     "nachname",
     "abteilung",
+    "amtsbezeichnung",
     "telefon",
     "email",
     "adresse_privat",

--- a/generator_abrechnung.py
+++ b/generator_abrechnung.py
@@ -423,9 +423,15 @@ def fill_pdf(data: AbrechnungData, input_pdf_path: str, output_dir: str) -> str:
 
     set_need_appearances(writer)
 
-    # Unterschrift Seite 2
+    # Unterschrift Seite 2 — der Vordruck beschriftet die Zeile mit
+    # „Unterschrift, Amtsbez./Datum"; daher Name, Amtsbezeichnung (falls
+    # vorhanden) und Datum in genau dieser Reihenfolge.
     heute = datetime.now().strftime(DATE_INPUT_FORMAT)
-    overlay = _create_signature_overlay(f"{data.antragsteller.name}, {heute}")
+    sig_parts = [data.antragsteller.name]
+    if data.antragsteller.amtsbezeichnung:
+        sig_parts.append(data.antragsteller.amtsbezeichnung)
+    sig_parts.append(heute)
+    overlay = _create_signature_overlay(", ".join(sig_parts))
     writer.pages[1].merge_page(overlay.pages[0], over=True)
 
     with open(output_pdf_path, "wb") as f:

--- a/models.py
+++ b/models.py
@@ -29,6 +29,10 @@ class Antragsteller(BaseModel):
     abteilung: str = Field(..., min_length=1, max_length=100)
     telefon: str = Field(..., min_length=5, max_length=50)
     adresse_privat: str = Field(..., min_length=5, max_length=200)
+    # Amtsbezeichnung (z.B. „Studienrat") — nur für die Abrechnung relevant
+    # (Signaturzeile „Unterschrift, Amtsbez./Datum"). Optional: nicht jeder
+    # hat eine (Angestellte), darf den Antrag/die Abrechnung nie blockieren.
+    amtsbezeichnung: str = Field(default="", max_length=100)
     mitreisender_name: str | None = ""
 
 
@@ -408,7 +412,7 @@ def bahncards_to_konfig_flags(bahncards: dict | None) -> dict:
     }
 
 
-_ANTRAGSTELLER_IDENTITY = ("name", "abteilung", "telefon", "adresse_privat")
+_ANTRAGSTELLER_IDENTITY = ("name", "abteilung", "amtsbezeichnung", "telefon", "adresse_privat")
 
 
 def apply_profile_authoritative(

--- a/models_db.py
+++ b/models_db.py
@@ -80,6 +80,11 @@ class UserProfile(Base):
     vorname: Mapped[str | None] = mapped_column(String(100))
     nachname: Mapped[str | None] = mapped_column(String(100))
     abteilung: Mapped[str | None] = mapped_column(String(100))
+    # Amtsbezeichnung (z.B. „Studienrat") — erscheint auf dem
+    # Reisekostenvordruck in der Signaturzeile „Unterschrift, Amtsbez./Datum".
+    # Nur abrechnungsrelevant; der DR-Antrag fragt sie nicht ab. Optional
+    # (Angestellte ohne Amtsbez. lassen es leer).
+    amtsbezeichnung: Mapped[str | None] = mapped_column(String(100))
     telefon: Mapped[str | None] = mapped_column(String(50))
     # Optional: Override der Authelia-Email. Wenn None, faellt der Wizard
     # auf User.email zurueck (kommt aus Authelia Remote-Email).

--- a/templates/abrechnung.html
+++ b/templates/abrechnung.html
@@ -365,6 +365,10 @@
               <input type="text" id="f_abteilung" data-bind="antragsteller.abteilung">
             </div>
             <div>
+              <label class="field-label" for="f_amtsbez">Amtsbezeichnung</label>
+              <input type="text" id="f_amtsbez" data-bind="antragsteller.amtsbezeichnung" placeholder="z.B. Studienrat">
+            </div>
+            <div>
               <label class="field-label" for="f_telefon">Telefon</label>
               <input type="text" id="f_telefon" data-bind="antragsteller.telefon">
             </div>
@@ -924,7 +928,7 @@
     function blankState() {
       return {
         stammdaten: { iban: '', bic: '', email: '', abrechnende_dienststelle: '' },
-        antragsteller: { name: '', abteilung: '', telefon: '', adresse_privat: '', mitreisender_name: '' },
+        antragsteller: { name: '', abteilung: '', amtsbezeichnung: '', telefon: '', adresse_privat: '', mitreisender_name: '' },
         reise_details: {
           zielort: '', reiseweg: '', zweck: '',
           start_datum: '', start_zeit: '', ende_datum: '', ende_zeit: '',
@@ -1042,6 +1046,7 @@
       // Profil ins state übernehmen, falls Felder noch leer
       if (!state.antragsteller.name) state.antragsteller.name = p.name || '';
       if (!state.antragsteller.abteilung) state.antragsteller.abteilung = p.abteilung || '';
+      if (!state.antragsteller.amtsbezeichnung) state.antragsteller.amtsbezeichnung = p.amtsbezeichnung || '';
       if (!state.antragsteller.telefon) state.antragsteller.telefon = p.telefon || '';
       if (!state.antragsteller.adresse_privat) state.antragsteller.adresse_privat = p.adresse || '';
       if (!state.antragsteller.mitreisender_name) state.antragsteller.mitreisender_name = p.mitreisender || '';

--- a/templates/index.html
+++ b/templates/index.html
@@ -265,6 +265,10 @@
             <input type="text" id="wiz_abrechnende" placeholder="NLBV Aurich">
           </div>
           <div class="wiz-field">
+            <label class="wiz-label" for="wiz_amtsbez">Amtsbezeichnung</label>
+            <input type="text" id="wiz_amtsbez" placeholder="z.B. Studienrat" maxlength="100">
+          </div>
+          <div class="wiz-field">
             <label class="wiz-label" for="wiz_rkr">Standard-Reiseart (RKR)</label>
             <select id="wiz_rkr">
               <option value="DR">DR – Dienstreise</option>
@@ -649,9 +653,10 @@
         wiz_standard_verkehrsmittel.value = p.standard_verkehrsmittel || '';
         wiz_iban.value = p.iban || ''; wiz_bic.value = p.bic || '';
         wiz_email.value = p.email || ''; wiz_abrechnende.value = p.abrechnende_dienststelle || '';
+        wiz_amtsbez.value = p.amtsbezeichnung || '';
         wiz_rkr.value = p.rkr_default || 'DR';
         wiz_deepseek_key.value = p.deepseek_api_key || '';
-        if (p.iban || p.bic || p.email || p.abrechnende_dienststelle) wizAbrechnungBlock.open = true;
+        if (p.iban || p.bic || p.email || p.abrechnende_dienststelle || p.amtsbezeichnung) wizAbrechnungBlock.open = true;
         if (p.deepseek_api_key) wizAIBlock.open = true;
       }
       openModal('wizardOverlay');
@@ -674,6 +679,7 @@
         bic: wiz_bic.value.trim().toUpperCase(),
         email: wiz_email.value.trim(),
         abrechnende_dienststelle: wiz_abrechnende.value.trim(),
+        amtsbezeichnung: wiz_amtsbez.value.trim(),
         rkr_default: wiz_rkr.value,
         deepseek_api_key: wiz_deepseek_key.value.trim(),
       });
@@ -884,6 +890,7 @@
         antragsteller: {
           name: p.name || '', abteilung: p.abteilung || '', telefon: p.telefon || '',
           adresse_privat: p.adresse || '', mitreisender_name: p.mitreisender || '',
+          amtsbezeichnung: p.amtsbezeichnung || '',
         },
         reise_details: {
           zielort: r_zielort.value.trim(), reiseweg: r_reiseweg.value.trim(), zweck: r_zweck.value.trim(),

--- a/templates/profil.html
+++ b/templates/profil.html
@@ -50,6 +50,7 @@
     <label>Nachname<input type="text" name="nachname" value="{{ profile.nachname or '' }}" maxlength="100"></label>
     <label>Abteilung<input type="text" name="abteilung" value="{{ profile.abteilung or '' }}" maxlength="100"></label>
     <label>Telefon<input type="text" name="telefon" value="{{ profile.telefon or '' }}" maxlength="50"></label>
+    <label>Amtsbezeichnung <small>(optional, nur Abrechnung)</small><input type="text" name="amtsbezeichnung" value="{{ profile.amtsbezeichnung or '' }}" maxlength="100" placeholder="z.B. Studienrat"></label>
   </div>
   <label style="margin-top:.8rem;">Privatadresse <small>(verschlüsselt)</small>
     <input type="text" name="adresse_privat" value="{{ profile.adresse_privat or '' }}" maxlength="200">

--- a/tests/test_profile_merge.py
+++ b/tests/test_profile_merge.py
@@ -112,6 +112,45 @@ def test_mitreisender_is_trip_specific():
     assert merged["antragsteller"]["mitreisender_name"] == "Reise-Kollege"
 
 
+def test_amtsbezeichnung_is_profile_authoritative():
+    """Amtsbez. ist Identitätsfeld → Profilwert gewinnt, ein vom Client
+    gefälschter Wert wird überschrieben. Optional: leeres Profil blockiert
+    den Antrag nicht (Antragsteller.amtsbezeichnung hat Default "")."""
+    data = _partial_ai_json()
+    data["befoerderung"] = {
+        "hinreise": {"typ": "PKW", "paragraph_5_nrkvo": "II"},
+        "rueckreise": {"typ": "PKW", "paragraph_5_nrkvo": "II"},
+    }
+    data["antragsteller"] = {
+        "name": "Client Name",
+        "abteilung": "Client Abt",
+        "telefon": "0591 12345",
+        "adresse_privat": "Client Str 1, 49808 Lingen",
+        "amtsbezeichnung": "vom-Client-gefälscht",
+        "mitreisender_name": "",
+    }
+    prof = {
+        "name": "Malte Zilinski",
+        "abteilung": "BBS Lingen",
+        "telefon": "+4917693122465",
+        "adresse_privat": "Am Biener Esch 11, 49808 Lingen",
+        "amtsbezeichnung": "Studienrat",
+        "mitreisender_name": "",
+    }
+    merged = apply_profile_authoritative(data, antragsteller=prof, bahncards={})
+    assert merged["antragsteller"]["amtsbezeichnung"] == "Studienrat"
+    ok, _ = validate_reiseantrag(merged)
+    assert ok is True
+
+    # Leeres Amtsbez. (Angestellte) darf nicht blockieren.
+    data["antragsteller"]["amtsbezeichnung"] = ""
+    prof["amtsbezeichnung"] = ""
+    merged2 = apply_profile_authoritative(data, antragsteller=prof, bahncards={})
+    assert merged2["antragsteller"]["amtsbezeichnung"] == ""
+    ok2, _ = validate_reiseantrag(merged2)
+    assert ok2 is True
+
+
 def test_bahncards_mapping_slot1_only():
     flags = bahncards_to_konfig_flags(
         {"bcb_1": True, "bc50_1": True, "grosskunde_1": True, "bcb_2": True, "grosskunde_2": True}


### PR DESCRIPTION
## Was
Amtsbezeichnung (z.B. „Studienrat") ist im Profil ablegbar und wird auf dem **Reisekostenvordruck** in der Signaturzeile „Unterschrift, Amtsbez./Datum" eingetragen.

**Scope-Korrektur ggü. ursprünglicher Idee:** Der **DR-Antrag** fragt keine Amtsbez. ab — im gedruckten Vordruck-Text kommt „Amtsbez" nirgends vor (verifiziert per Text-Dump). Nur der Reisekostenvordruck (Abrechnung) hat sie. → Antrag-Generator **unverändert**.

## Änderungen
- **DB**: `UserProfile.amtsbezeichnung` (String 100, optional) + Alembic `007_amtsbezeichnung` (läuft via `alembic upgrade head` beim Container-Start, idempotent — Muster wie 006).
- **Profil-Eingabe**: `profil.html` (Server-Profil), „Profil einrichten"-Modal in `index.html` (Gäste/localStorage), Abrechnungs-Stammdaten-Step `abrechnung.html` (`f_amtsbez`, editierbar).
- **Profil-autoritativ**: in `_ANTRAGSTELLER_IDENTITY` aufgenommen; fließt über `_profile_antrag_overrides` + `_build_wizard_profile_seed` + `_PROFIL_FIELDS_TEXT` (POST/JSON automatisch). Optional, Default `""` → blockiert nie (Angestellte ohne Amtsbez.).
- **PDF**: `generator_abrechnung.py` Signatur-Overlay → `Name, Amtsbez., Datum` in der vom Vordruck vorgegebenen Reihenfolge (Amtsbez. weggelassen wenn leer).
- **Model**: `Antragsteller.amtsbezeichnung: str = ""`.

## Verifiziert
- Sample-Abrechnung gerendert: Signaturzeile zeigt korrekt „Max Mustermann, Studienrat, 16.05.2026" unter „Unterschrift, Amtsbez./Datum", kein Overflow, Position unverändert.
- Lokal CI gespiegelt: `ruff check`/`ruff format` ✓, **152 pytest passed** (inkl. neuer `test_amtsbezeichnung_is_profile_authoritative`: profil-autoritativ + leer blockiert nicht), bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)