### PR TITLE
feat(antrag): gespeicherte Reise im Wizard editierbar (nur eingeloggt)

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -114,7 +114,7 @@
         {% endif %}
       </td>
       <td class="actions">
-        <a href="{{ url_for('index', dienstreise=r.id) }}">Antrag</a>
+        <a href="{{ url_for('index', dienstreise=r.id) }}">{% if r.antrag_pdf_path %}Antrag bearbeiten{% else %}Antrag{% endif %}</a>
         {% if r.antrag_pdf_path %}
           <a href="{{ url_for('dienstreise_antrag_pdf', reise_id=r.id) }}">PDF</a>
         {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -735,6 +735,51 @@
         sonderfall_begruendung_textfeld: sonderfall.value.trim(),
       };
     }
+
+    // Step-2-Formular aus einer gespeicherten befoerderung rehydrieren
+    // (Reload zum Editieren — Gegenstück zu getReiseAnswers()).
+    function applyBefoerderung(b) {
+      if (!b) return;
+      const set = (typEl, paraEl, mfId, r) => {
+        if (!r) return;
+        if (r.typ) typEl.value = r.typ;
+        if (r.typ === 'PKW' && r.paragraph_5_nrkvo) paraEl.value = r.paragraph_5_nrkvo;
+        if (r.typ === 'MITFAHRT' && r.mitfahrer_name) document.getElementById(mfId).value = r.mitfahrer_name;
+      };
+      set(hin_typ, hin_para, 'hin_mitfahrer', b.hinreise);
+      set(rueck_typ, rueck_para, 'rueck_mitfahrer', b.rueckreise);
+      if (b.sonderfall_begruendung_textfeld) sonderfall.value = b.sonderfall_begruendung_textfeld;
+      updateBefoerderungUI();
+    }
+
+    // Reload zum Editieren (nur eingeloggt): gespeicherte Reise zurück in
+    // den Wizard holen. Es werden NUR Nicht-Profil-Felder rehydriert —
+    // antragsteller bleibt profil-autoritativ (Server überschreibt beim
+    // Regenerieren). dienstreise_id wird gesetzt → /generate überschreibt
+    // die bestehende Reise statt eine neue anzulegen.
+    async function autoLoadAntrag(reiseId) {
+      try {
+        const r = await fetch(`/dienstreisen/${reiseId}/antrag-json`, { headers: { 'Accept': 'application/json' } });
+        if (!r.ok) { showAlert('Reise konnte nicht geladen werden.', 'warning'); return; }
+        const d = await r.json();
+        const aj = d.antrag_json;
+        if (!aj) { showAlert('Diese Reise hat noch kein gespeichertes Antrag-JSON.', 'warning'); return; }
+        aiData = aj;  // fillReview() liest reise_details/zusatz_infos/konfiguration/verzicht hieraus
+        applyBefoerderung(aj.befoerderung);
+        let h = document.getElementById('dienstreiseId');
+        if (!h) {
+          h = document.createElement('input');
+          h.type = 'hidden'; h.id = 'dienstreiseId'; h.name = 'dienstreise_id';
+          document.getElementById('genForm').appendChild(h);
+        }
+        h.value = String(reiseId);
+        fillReview();
+        goStep(4);
+        showAlert(`Reise #${reiseId} geladen — Werte editierbar. „PDF erzeugen" überschreibt die gespeicherte Reise.`, 'success');
+      } catch (e) {
+        showAlert('Laden fehlgeschlagen: ' + e.message, 'warning');
+      }
+    }
     const VM_LABEL = { PKW:'PKW (selbst gefahren)', BAHN:'Bahn', BUS:'Bus', DIENSTWAGEN:'Dienstwagen', MITFAHRT:'Mitfahrt', FLUG:'Flug' };
     function formatReiseKontext(ra) {
       const line = (richtung, t) => {
@@ -1103,7 +1148,12 @@
       prefillBefoerderung();
       const badge = document.getElementById('saveStatus');
       if (badge) { const auto = p && p.auto_save_dienstreisen !== false; badge.style.display = auto ? 'block' : 'none'; }
-      if ((!p || !(p.name || p.abteilung)) && !IS_AUTHENTICATED) setTimeout(() => openWizard(), 400);
+      const editId = new URLSearchParams(location.search).get('dienstreise');
+      if (editId && IS_AUTHENTICATED) {
+        autoLoadAntrag(editId);
+      } else if ((!p || !(p.name || p.abteilung)) && !IS_AUTHENTICATED) {
+        setTimeout(() => openWizard(), 400);
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Was
Eine bereits erzeugte Reise lässt sich jetzt im **Antrag-Wizard** wieder öffnen und korrigieren (falls mal was falsch eingetragen wurde) — bisher ging das nur bei der Abrechnung.

## Warum klein
Die Server-Seite war bereits vollständig da: `antrag_json` wird persistiert, `/dienstreisen/<id>/antrag-json` liefert es, `/generate` überschreibt bei mitgesendeter `dienstreise_id`. Es fehlte nur die **Client-Rehydration** im Antrag-Wizard (die Abrechnung hatte sie schon via `autoLoadFromDashboard`).

## Änderungen (nur Templates)
- **`index.html`**: `autoLoadAntrag()` — bei `?dienstreise=N` **und** eingeloggt: holt `antrag_json`, rehydriert **nur Nicht-Profil-Felder** (`reise_details`, `befoerderung`, `konfiguration_checkboxen`, `bemerkungen_feld`, `verzicht_erklaerung`) via `aiData → fillReview() → Step 4`, setzt verstecktes `dienstreise_id` → `/generate` überschreibt die Reise. `applyBefoerderung()` als Gegenstück zu `getReiseAnswers()`.
- **`dashboard.html`**: Link „Antrag bearbeiten" (wenn schon Antrag-PDF existiert), analog zur Abrechnungs-Beschriftung.

## Designentscheidung (wie abgestimmt)
- **Identität bleibt profil-autoritativ**: `antragsteller` wird NICHT aus dem alten JSON geladen — der Server überschreibt es beim Regenerieren aus dem aktuellen Profil (Profiländerungen, z.B. neue Amtsbez., ziehen automatisch auch in alte Reisen). Single Source of Truth = Profil.
- **Nur eingeloggte Nutzer** (Guard `?dienstreise && IS_AUTHENTICATED`). Gäste: kein Reload-Einstieg, Onboarding-Modal-Verhalten unverändert.
- Abrechnung kann das bereits (`mergeIntoState` + editierbare `data-bind`-Felder) — kein Eingriff nötig.

## Verifiziert
- Lokal CI gespiegelt: `ruff check`/`ruff format` ✓, **151 pytest passed** (keine Python-Änderung; `/antrag-json`-Endpoint ist in `test_dashboard.py` abgedeckt — Owner/Cross-User/Roundtrip), bandit clean.
- **E2E (Playwright, authentifiziert, lokales Image)**: Reise erzeugen → `?dienstreise=N` → Step 4 rehydriert (Zielort/Zweck/Bemerkungen/`k_kosten_andere`), Antragsteller aus Profil, `dienstreise_id` gesetzt, Re-Submit überschreibt **dieselbe** Reise (X-Dienstreise-Id stabil) — **10/10 PASS**, Screenshot geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)