### PR TITLE
fix(ai): kosten_durch_andere_stelle nur bei echter Drittübernahme (Variante B)

### DIFF
--- a/system_prompt.md
+++ b/system_prompt.md
@@ -33,7 +33,7 @@ Alle Booleans haben Default `false`. Setze `true` nur, wenn der Input es **ausdr
 |------|-------------------------------------|
 | `dienstgeschaeft_2km_umkreis` | Dienstort liegt nachweislich < 2 km von Dienststätte/Wohnung |
 | `anspruch_trennungsgeld` | mehrtägige Reise mit auswärtigem Verbleiben **und** im Input genannter Trennungsgeld-Anspruch |
-| `kosten_durch_andere_stelle` | Veranstalter trägt Reisekosten ganz/teilweise — typisch: Tagungsgebühr inkl. Übernachtung und/oder Verpflegung |
+| `kosten_durch_andere_stelle` | der Input sagt **ausdrücklich**, dass ein Dritter (Veranstalter / Dienstherr / andere Stelle) die **Reisekosten** ganz oder teilweise **übernimmt oder erstattet** (z. B. „Reisekosten werden vom Veranstalter getragen", „Fahrtkosten übernimmt das LfB"). **NICHT** setzen, nur weil eine vom Teilnehmer selbst gezahlte Tagungs-/Schulungs-/Seminargebühr Übernachtung/Verpflegung enthält — das ist Eigenzahlung einer Bündelleistung, keine Kostenübernahme durch eine andere Stelle |
 | `weitere_anmerkungen_checkbox_aktivieren` | `bemerkungen_feld` hat Inhalt — dann `true` |
 
 `verzicht_tagegeld` / `verzicht_uebernachtungsgeld` / `verzicht_fahrtkosten`: **immer `false`** — einen Verzicht erklärt der Nutzer später selbst, nicht du.


### PR DESCRIPTION
## Problem
Die KI setzte `kosten_durch_andere_stelle = true` bereits, wenn eine Tagungs-/Schulungsgebühr Übernachtung/Verpflegung enthielt. Das ist bei Fortbildungen der **Normalfall** (Teilnehmer zahlt die Gebühr selbst) → Box war fälschlich vorab gecheckt (vom Nutzer gemeldet, war als offene Frage in #14 vermerkt).

## Fix — Variante B (gewählt)
`system_prompt.md` Abschnitt 5, Regel für `kosten_durch_andere_stelle` verschärft:
- **`true` nur**, wenn der Input **ausdrücklich** sagt, dass ein Dritter (Veranstalter / Dienstherr / andere Stelle) die **Reisekosten** ganz/teilweise **übernimmt oder erstattet**.
- **Explizit NICHT** mehr, nur weil eine selbst gezahlte Bündelgebühr Übernachtung/Verpflegung enthält (= Eigenzahlung, keine Drittübernahme).

1 Zeile, Default bleibt `false`.

## Bewusst nicht mitgemacht (Scope)
Kein separater „Verpflegung gestellt → Tagegeld-Kürzung"-Automatismus — der Trade-off (Box feuert seltener, Kürzung muss ggf. manuell) wurde vorab besprochen und mit Variante B akzeptiert. Der Nutzer hakt die Box im Wizard bei Bedarf weiterhin selbst an.

## Verifiziert
`ruff` ✓ (keine Py-Änderung), **152 pytest passed** inkl. `test_system_prompt_strips_profile_section` (Strip-/Schema-Verträge unverändert), `test_ai_extract` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)